### PR TITLE
Added psr/cache v2 to allowed versions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "typo3/cms-core": "^10.4 || ^11.4 || ^12.1",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Added psr/cache v2 to allowed versions in order to be able to install t3_messenger in TYPO3 v12 LTS