### PR TITLE
Add DateInterval as allowed input for expiresAfter, fix expiry time calculation, adapt tests

### DIFF
--- a/Classes/Adapter/Psr6Adapter.php
+++ b/Classes/Adapter/Psr6Adapter.php
@@ -83,7 +83,7 @@ final class Psr6Adapter implements CacheItemPoolInterface
             $lifetime = null;
 
             if (method_exists($item, 'getExpiry')) {
-                $lifetime = $item->getExpiry() ? (int) ($GLOBALS['EXEC_TIME'] - $item->getExpiry()) : null;
+                $lifetime = $item->getExpiry() ? (int) ($item->getExpiry() - $GLOBALS['EXEC_TIME']) : null;
             }
 
             $this->cache->set($this->hash($item->getKey()), $item->get(), [], $lifetime);

--- a/Classes/CacheItem.php
+++ b/Classes/CacheItem.php
@@ -81,9 +81,12 @@ final class CacheItem implements CacheItemInterface
             $this->expiry = null;
         } elseif (is_int($time)) {
             $this->expiry = (int) ($GLOBALS['EXEC_TIME'] + $time);
+        } elseif ($time instanceof \DateInterval) {
+            $this->expiry = (new \DateTime('@0'))->add($time)
+                ->getTimestamp() + $GLOBALS['EXEC_TIME'];
         } else {
             throw new InvalidArgumentException(sprintf(
-                'Expiration date must be an integer, "%s" given.',
+                'Expiration date must be null, integer or DateInterval, "%s" given.',
                 get_debug_type($time)
             ));
         }

--- a/Tests/Functional/Adapter/Psr16CacheAdapterTest.php
+++ b/Tests/Functional/Adapter/Psr16CacheAdapterTest.php
@@ -55,7 +55,7 @@ final class Psr16CacheAdapterTest extends FunctionalTestCase
      * @dataProvider expiresAfterTimeProvider
      * @param DateInterval|int|null $input
      */
-    public function testThatFirstCalculationCreatesCacheEntry(string $expected, mixed $input): void
+    public function testThatFirstCalculationCreatesCacheEntry(string $expected, $input): void
     {
         $this->cacheAdapter->clear();
         $this->serviceWithPsr16Cache->calculate($input);
@@ -70,7 +70,7 @@ final class Psr16CacheAdapterTest extends FunctionalTestCase
      * @dataProvider expiresAfterTimeProvider
      * @param DateInterval|int|null $input
      */
-    public function testThatGetItemsReturnsCorrectResults(string $expected, mixed $input): void
+    public function testThatGetItemsReturnsCorrectResults(string $expected, $input): void
     {
         $this->cacheAdapter->clear();
         $this->serviceWithPsr16Cache->calculate($input);

--- a/Tests/Functional/Adapter/Psr6AdapterTest.php
+++ b/Tests/Functional/Adapter/Psr6AdapterTest.php
@@ -55,7 +55,7 @@ final class Psr6AdapterTest extends FunctionalTestCase
      * @dataProvider expiresAfterTimeProvider
      * @param DateInterval|int|null $input
      */
-    public function testThatFirstCalculationCreatesCacheEntry(string $expected, mixed $input): void
+    public function testThatFirstCalculationCreatesCacheEntry(string $expected, $input): void
     {
         $this->cacheAdapter->clear();
         $this->serviceWithPsr6Cache->calculate($input);
@@ -70,7 +70,7 @@ final class Psr6AdapterTest extends FunctionalTestCase
      * @dataProvider expiresAfterTimeProvider
      * @param DateInterval|int|null $input
      */
-    public function testThatGetItemsReturnsCorrectResults(string $expected, mixed $input): void
+    public function testThatGetItemsReturnsCorrectResults(string $expected, $input): void
     {
         $this->cacheAdapter->clear();
         $this->serviceWithPsr6Cache->calculate($input);
@@ -86,7 +86,7 @@ final class Psr6AdapterTest extends FunctionalTestCase
     //     * @param string $expected
     //     * @param DateInterval|int|null $input
     //     */
-    //    public function testThatLifetimeIsCorrectlySet(string $expected, mixed $input): void
+    //    public function testThatLifetimeIsCorrectlySet(string $expected, $input): void
     //    {
     //        $this->cacheAdapter->clear();
     //        $this->serviceWithPsr6Cache->calculate($input);

--- a/Tests/Functional/Fixtures/Extensions/typo3_psr_cache_adapter_test/Classes/Service/ServiceWithPsr16Cache.php
+++ b/Tests/Functional/Fixtures/Extensions/typo3_psr_cache_adapter_test/Classes/Service/ServiceWithPsr16Cache.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Ssch\Cache\Tests\Functional\Fixtures\Extensions\typo3_psr_cache_adapter_test\Classes\Service;
 
+use DateInterval;
 use Psr\SimpleCache\CacheInterface;
 
 final class ServiceWithPsr16Cache
@@ -26,7 +27,10 @@ final class ServiceWithPsr16Cache
         $this->cache = $cache;
     }
 
-    public function calculate(int $lifetime = null): void
+    /**
+     * @param DateInterval|int|null $lifetime
+     */
+    public function calculate($lifetime = null): void
     {
         if (! $this->cache->has(self::CACHE_ITEM_KEY)) {
             $this->cache->set(self::CACHE_ITEM_KEY, md5(self::CACHE_VALUE), $lifetime);

--- a/Tests/Functional/Fixtures/Extensions/typo3_psr_cache_adapter_test/Classes/Service/ServiceWithPsr6Cache.php
+++ b/Tests/Functional/Fixtures/Extensions/typo3_psr_cache_adapter_test/Classes/Service/ServiceWithPsr6Cache.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Ssch\Cache\Tests\Functional\Fixtures\Extensions\typo3_psr_cache_adapter_test\Classes\Service;
 
+use DateInterval;
 use Psr\Cache\CacheItemPoolInterface;
 
 final class ServiceWithPsr6Cache
@@ -26,7 +27,10 @@ final class ServiceWithPsr6Cache
         $this->cacheItemPool = $cacheItemPool;
     }
 
-    public function calculate(int $lifetime = null): void
+    /**
+     * @param DateInterval|int|null $lifetime
+     */
+    public function calculate($lifetime = null): void
     {
         $cacheItem = $this->cacheItemPool->getItem(self::CACHE_ITEM_KEY);
         if (! $cacheItem->isHit()) {


### PR DESCRIPTION
- The method expiresAfter in CacheItem.php needs to accept DateInterval, see Interface at https://github.com/php-fig/cache/blob/master/src/CacheItemInterface.php#L104
- The calculation for the lifetime in Classes/Adapter/Psr6Adapter.php was wrong. Instead of lifetime = current_time - expiry_time it needs to be lifetime = expiry_time - current_time, else the values will become negative
- I tried to update the tests for this, but was not able to fix the testThatLifetimeIsCorrectlySet test in Tests/Functional/Adapter/Psr6AdapterTest.php. It seems that this test only worked before, because setting the lifetime there as 1 had no effect - lifetime was calculated to -1 due the above bug and therefore the cache item was never written. 